### PR TITLE
Remove copying config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,9 +124,6 @@ ENV LOTUS_STORAGE_PATH=/data/storage/
 #Install rosetta proxy
 COPY --from=builder ${PROXYPATH}/filecoin-indexing-rosetta-proxy /usr/local/bin
 
-# Copy config files
-COPY --from=builder ${PROXYPATH}/config.yaml /
-
 ENV LOTUS_RPC_URL=ws://127.0.0.1:1234/rpc/v0
 ENV LOTUS_RPC_TOKEN=""
 


### PR DESCRIPTION
Rosetta-proxy config file is mounted and managed by kubernetes